### PR TITLE
disable-macro-warnings made a global setting.

### DIFF
--- a/src/Entry.cpp
+++ b/src/Entry.cpp
@@ -176,8 +176,7 @@ int main(int argc, char** argv)
 	TCLAP::SwitchArg disableClassnameCheckArg("c", "check-classnames", "Enables the config checking for eg. createVehicle.", false);
 	cmd.add(disableClassnameCheckArg);
 
-	TCLAP::SwitchArg disableMacroWarningsArg("", "disable-macro-warnings", "Disables the warning for duplicate defines and undefines without a corresponding define.\n"
-		"Note that this will only disable theese for CLI related input.", false);
+	TCLAP::SwitchArg disableMacroWarningsArg("", "disable-macro-warnings", "Disables the warning for duplicate defines and undefines without a corresponding define.\n", false);
 	cmd.add(disableMacroWarningsArg);
 
 
@@ -332,6 +331,7 @@ int main(int argc, char** argv)
 
 	auto debugger_port = debuggerArg.getValue();
 
+	sqf::parse::preprocessor::settings::disable_warn_define = disableMacroWarningsArg.getValue();
 
 	sqf::virtualmachine vm;
 	sqf::commandmap::get().init();
@@ -471,7 +471,7 @@ int main(int argc, char** argv)
 			{
 				std::cout << "Preprocessing file '" << sanitized << std::endl;
 			}
-			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized, disableMacroWarningsArg.getValue());
+			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized);
 			if (err)
 			{
 				vm.err_buffprint();
@@ -515,7 +515,7 @@ int main(int argc, char** argv)
 			{
 				std::cout << "Preprocessing file '" << sanitized << std::endl;
 			}
-			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized, disableMacroWarningsArg.getValue());
+			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized);
 			if (err)
 			{
 				vm.err_buffprint();
@@ -568,7 +568,7 @@ int main(int argc, char** argv)
 			{
 				std::cout << "Preprocessing file '" << sanitized << std::endl;
 			}
-			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized, disableMacroWarningsArg.getValue());
+			auto ppedStr = sqf::parse::preprocessor::parse(&vm, str, err, sanitized);
 			if (err)
 			{
 				vm.err_buffprint();
@@ -604,6 +604,7 @@ int main(int argc, char** argv)
 		sqf::commandmap::get().uninit();
 		return errflag ? -1 : 0;
 	}
+
 	//Load all sqf-code provided via arg.
 	for (auto& raw : sqfArg.getValue())
 	{
@@ -663,8 +664,7 @@ int main(int argc, char** argv)
 				&vm,
 				input,
 				err,
-				(std::filesystem::path(executable_path) / "__commandlinefeed.sqf").string(),
-				disableMacroWarningsArg.getValue()
+				(std::filesystem::path(executable_path) / "__commandlinefeed.sqf").string()
 			);
 			if (err || vm.err_hasdata())
 			{
@@ -690,7 +690,7 @@ int main(int argc, char** argv)
 				}
 				if (vm.err_hasdata())
 				{
-				    vm.err_buffprint();
+					vm.err_buffprint();
 				}
 			}
 		}

--- a/src/parsepreprocessor.cpp
+++ b/src/parsepreprocessor.cpp
@@ -676,7 +676,7 @@ namespace {
 			}
 			
 			auto res = h.macros.find(line);
-			if (res != h.macros.end())
+			if (res == h.macros.end())
 			{
 				if (h.warn_define)
 				{

--- a/src/parsepreprocessor.cpp
+++ b/src/parsepreprocessor.cpp
@@ -494,7 +494,6 @@ namespace {
 
 	std::string parse_macro(helper& h, finfo& fileinfo)
 	{
-		char c;
 		bool was_new_line = true;
 		auto inst = fileinfo.get_word();
 		auto line = fileinfo.get_line(true);
@@ -677,7 +676,7 @@ namespace {
 			}
 			
 			auto res = h.macros.find(line);
-			if (res == h.macros.end())
+			if (res != h.macros.end())
 			{
 				if (h.warn_define)
 				{

--- a/src/parsepreprocessor.cpp
+++ b/src/parsepreprocessor.cpp
@@ -12,6 +12,16 @@
 
 using namespace sqf::parse::preprocessor;
 
+namespace sqf {
+    namespace parse {
+        namespace preprocessor {
+            namespace settings {
+                bool disable_warn_define = false;
+            }
+        }
+    }
+}
+
 namespace {
 	class helper
 	{
@@ -23,9 +33,6 @@ namespace {
 		bool allowwrite = true;
 		bool inside_ppif = false;
 
-		// Wether or not to warn on non-existing #undef
-		// and already-existing #define
-		bool warn_define = true;
 
 		std::optional<macro> contains_macro(std::string mname)
 		{
@@ -40,6 +47,7 @@ namespace {
 			}
 		}
 	};
+
 	std::string handle_macro(helper& h, finfo& fileinfo, const macro& m);
 	std::string replace(helper& h, finfo& fileinfo, const macro& m, std::vector<std::string> params);
 	std::string handle_arg(helper& h, finfo& fileinfo, size_t endindex);
@@ -588,7 +596,7 @@ namespace {
 			if (bracketsIndex == std::string::npos && spaceIndex == std::string::npos)
 			{ // Empty define
 				m.name = line;
-				if (h.macros.find(m.name) != h.macros.end() && h.warn_define)
+				if (h.macros.find(m.name) != h.macros.end() && !settings::disable_warn_define)
 				{
 					if (fileinfo.path.empty())
 					{
@@ -605,7 +613,7 @@ namespace {
 				if (spaceIndex < bracketsIndex || bracketsIndex == std::string::npos) // std::string::npos does not need to be catched as bracketsIndex always < npos here
 				{ // First bracket was found after first space OR is not existing thus we have a simple define with a replace value here
 					m.name = line.substr(0, spaceIndex);
-					if (h.macros.find(m.name) != h.macros.end() && h.warn_define)
+					if (h.macros.find(m.name) != h.macros.end() && !settings::disable_warn_define)
 					{
 						if (fileinfo.path.empty())
 						{
@@ -623,7 +631,7 @@ namespace {
 				{ // We got a define with arguments here
 					m.hasargs = true;
 					m.name = line.substr(0, bracketsIndex);
-					if (h.macros.find(m.name) != h.macros.end() && h.warn_define)
+					if (h.macros.find(m.name) != h.macros.end() && !settings::disable_warn_define)
 					{
 						if (fileinfo.path.empty())
 						{
@@ -678,7 +686,7 @@ namespace {
 			auto res = h.macros.find(line);
 			if (res == h.macros.end())
 			{
-				if (h.warn_define)
+				if (!settings::disable_warn_define)
 				{
 					if (fileinfo.path.empty())
 					{
@@ -945,11 +953,10 @@ std::string file_macro_callback(finfo fileinfo, std::vector<std::string> params)
 {
 	return '"' + fileinfo.path + '"';
 }
-std::string sqf::parse::preprocessor::parse(sqf::virtualmachine* vm, std::string input, bool & errflag, std::string filename, bool warn_define)
+std::string sqf::parse::preprocessor::parse(sqf::virtualmachine* vm, std::string input, bool & errflag, std::string filename)
 {
 	helper h;
 	h.vm = vm;
-	h.warn_define = warn_define;
 	{
 		macro macro;
 		macro.line = 0;

--- a/src/parsepreprocessor.h
+++ b/src/parsepreprocessor.h
@@ -217,8 +217,15 @@ namespace sqf
 				macro() : name(), content(), args(), filepath(), line(0), column(0), hasargs(false), callback(nullptr) {}
 			};
 
+			namespace settings
+			{
+				// Whether or not to warn on non-existing #undef
+				// and already-existing #define
+				extern bool disable_warn_define;
+			};
 
-			std::string parse(sqf::virtualmachine* vm, std::string input, bool &errflag, std::string filename, bool warn_define = true);
+
+			std::string parse(sqf::virtualmachine* vm, std::string input, bool &errflag, std::string filename);
 		}
 	}
 }


### PR DESCRIPTION
It gives consistent behavior across all preproc operations now.