### PR TITLE
Fix GCC non-const ref

### DIFF
--- a/src/Entry.cpp
+++ b/src/Entry.cpp
@@ -626,7 +626,7 @@ int main(int argc, char** argv)
 	}
 
 	// Load all sqf-code provided via arg.
-	for (auto& raw = sqfArg.getValue().rbegin(); raw != sqfArg.getValue().rend(); raw++)
+	for (const auto& raw = sqfArg.getValue().rbegin(); raw != sqfArg.getValue().rend(); raw++)
 	{
 		vm.parse_sqf(*raw);
 	}

--- a/src/Entry.cpp
+++ b/src/Entry.cpp
@@ -626,7 +626,7 @@ int main(int argc, char** argv)
 	}
 
 	// Load all sqf-code provided via arg.
-	for (const auto& raw = sqfArg.getValue().rbegin(); raw != sqfArg.getValue().rend(); raw++)
+	for (auto raw = sqfArg.getValue().rbegin(); raw != sqfArg.getValue().rend(); raw++)
 	{
 		vm.parse_sqf(*raw);
 	}


### PR DESCRIPTION
Cant store a temporary as a non-const reference.
Adding const will break the raw++
so just make it non-ref, copying a iterator is cheap.

Please Squash&Merge