### PR TITLE
Add header file required to prevent missing uint32_t error on clang

### DIFF
--- a/src/parser/pbo/parsepbo.h
+++ b/src/parser/pbo/parsepbo.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 #include <array>
 #include <vector>
 #include <string>


### PR DESCRIPTION
I have only tested this on my local version of clang (`Ubuntu clang version 18.1.3 (1ubuntu1)`) so testing to require compatibilty for other platforms may still be required